### PR TITLE
Make the menu actually behave as expected.

### DIFF
--- a/LFRun/MainWindow.xaml
+++ b/LFRun/MainWindow.xaml
@@ -46,7 +46,7 @@
 
                 <Image Grid.Row="0" Grid.Column="0" Source="{StaticResource LFRun}" Width="36" Height="36" Stretch="Uniform" Margin="0 16 0 0"/>
                 <Label Grid.Row="0" Grid.Column="1" Margin="0 16 0 0">
-                    <TextBlock TextWrapping="Wrap" HorizontalAlignment="Right">
+                    <TextBlock TextWrapping="Wrap">
                         Type the name of a program, folder, document, or Internet resource, and Windows will open it for you.
                     </TextBlock>
                 </Label>

--- a/LFRun/MainWindow.xaml
+++ b/LFRun/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Run (As Administrator)" Height="Auto" Width="410" SizeToContent="Height"
         ResizeMode="NoResize"
-        >
+        KeyUp="MainWindow_OnKeyUp">
     <Window.Resources>
         <ResourceDictionary>
             <BitmapImage x:Key="LFRun" UriSource="Resources/LFRun.ico" />
@@ -18,15 +18,12 @@
     </Window.Resources>
     <Window.InputBindings>
         <KeyBinding Key="F1" Command="{Binding AboutCommand}" />
-        <KeyBinding Key="LeftAlt" Modifiers="Alt" Command="{Binding ShowMenuCommand}" />
-        <KeyBinding Key="RightAlt" Modifiers="Alt" Command="{Binding ShowMenuCommand}" />
     </Window.InputBindings>
     <Border BorderThickness="0 1 0 0" BorderBrush="#11000000">
         <DockPanel LastChildFill="True">
             <Menu Name="MainMenu" DockPanel.Dock="Top" 
-                  Visibility="{Binding ShowMenu, Converter={StaticResource BoolToVis}}"
-                  LostFocus="MainMenu_OnLostFocus">
-                <MenuItem Header="_File">
+                  Visibility="{Binding ShowMenu, Converter={StaticResource BoolToVis}}"> 
+                <MenuItem Header="_File" SubmenuClosed="MenuItem_Hide">
                     <MenuItem Header="_About..." Command="{Binding AboutCommand}" />
                     <MenuItem Header="_Options">
                         <MenuItem Header="_Save History" IsCheckable="True" IsChecked="{Binding SaveHistory}" Command="{Binding SaveHistoryCheckedCommand}" />
@@ -49,7 +46,7 @@
 
                 <Image Grid.Row="0" Grid.Column="0" Source="{StaticResource LFRun}" Width="36" Height="36" Stretch="Uniform" Margin="0 16 0 0"/>
                 <Label Grid.Row="0" Grid.Column="1" Margin="0 16 0 0">
-                    <TextBlock TextWrapping="Wrap">
+                    <TextBlock TextWrapping="Wrap" HorizontalAlignment="Right">
                         Type the name of a program, folder, document, or Internet resource, and Windows will open it for you.
                     </TextBlock>
                 </Label>

--- a/LFRun/MainWindow.xaml.cs
+++ b/LFRun/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
 using LFRun.ViewModels;
@@ -44,7 +45,7 @@ namespace LFRun
         {
             Left = 0;
             Top = SystemParameters.WorkArea.Height - ActualHeight;
-            InputComboBox.Focus();    
+            InputComboBox.Focus(); 
         }
 
         protected override void OnSourceInitialized(EventArgs e)
@@ -80,21 +81,21 @@ namespace LFRun
             return IntPtr.Zero;
         }
 
-        private void MainMenu_OnLostFocus(object sender, RoutedEventArgs e)
-        {
-            MainWindowViewModel mwvm = (MainWindowViewModel)DataContext;
-
-            mwvm.ShowMenu = false;
-        }
-
         private void MainWindow_OnKeyUp(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.System && (e.SystemKey == Key.LeftAlt || e.SystemKey == Key.RightAlt))
             {
                 MainWindowViewModel mwvm = (MainWindowViewModel)DataContext;
 
-                mwvm.ShowMenuCommand.Execute(null);
+                mwvm.ShowMenu = !mwvm.ShowMenu;
             }
+        }
+
+        private void MenuItem_Hide(object sender, RoutedEventArgs e)
+        {
+            MainWindowViewModel mwvm = (MainWindowViewModel)DataContext;
+
+            mwvm.ShowMenu = false;
         }
     }
 }

--- a/LFRun/ViewModels/MainWindowViewModel.cs
+++ b/LFRun/ViewModels/MainWindowViewModel.cs
@@ -23,8 +23,6 @@ namespace LFRun.ViewModels
 
         public ICommand SaveHistoryCheckedCommand { get; }
 
-        public ICommand ShowMenuCommand { get; }
-
         private string _runButtonText = "Run";
 
         public string RunButtonText
@@ -49,7 +47,7 @@ namespace LFRun.ViewModels
             set => SetProperty(ref _history, value);
         }
 
-        private bool _showMenu;
+        private bool _showMenu = false;
         public bool ShowMenu
         {
             get => _showMenu;
@@ -74,9 +72,6 @@ namespace LFRun.ViewModels
 
             SaveHistoryCheckedCommand = new RelayCommand(
                 param => WriteRegistry("SaveHistory", SaveHistory ? 1 : 0, RegistryValueKind.DWord));
-
-            ShowMenuCommand = new RelayCommand(
-                _ => ShowMenu = !ShowMenu);
 
             _saveHistory = GetShouldSaveHistory();
 

--- a/LFRun/ViewModels/MainWindowViewModel.cs
+++ b/LFRun/ViewModels/MainWindowViewModel.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
-using System.Security.AccessControl;
 using System.Windows;
 using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using Microsoft.Win32;
 
@@ -71,7 +67,7 @@ namespace LFRun.ViewModels
                 param => !string.IsNullOrWhiteSpace(param));
 
             SaveHistoryCheckedCommand = new RelayCommand(
-                param => WriteRegistry("SaveHistory", SaveHistory ? 1 : 0, RegistryValueKind.DWord));
+                _ => WriteRegistry("SaveHistory", SaveHistory ? 1 : 0, RegistryValueKind.DWord));
 
             _saveHistory = GetShouldSaveHistory();
 


### PR DESCRIPTION
This fixes the menu behavior. Menu is now normally hidden (until alt is pressed). When the user selects an item or clicks away, the menu hides itself again.

This is NOT bound to the keyboard manipulation mode, so it is possible for this to become out of sync, though clicking away from the menu or selecting an option causes the menu to close so it's unlikely.